### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -27,7 +27,7 @@ waitForSPI	KEYWORD2
 receivePacket	KEYWORD2
 getData	KEYWORD2
 sendPacket	KEYWORD2
-printPacket KEYWORD2
+printPacket	KEYWORD2
 
 enableRotationVector	KEYWORD2
 enableGameRotationVector	KEYWORD2
@@ -71,7 +71,7 @@ getLinAccelZ	KEYWORD2
 getLinAccelAccuracy	KEYWORD2
 
 calibrateAccelerometer	KEYWORD2
-calibrateGyro	KEYWORD2		
+calibrateGyro	KEYWORD2
 calibrateMagnetometer	KEYWORD2
 calibratePlanarAccelerometer	KEYWORD2
 calibrateAll	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords