### PR TITLE
Fix the Q point used for heading accuracy estimate.

### DIFF
--- a/src/SparkFun_BNO080_Arduino_Library.cpp
+++ b/src/SparkFun_BNO080_Arduino_Library.cpp
@@ -372,7 +372,7 @@ float BNO080::getQuatReal()
 //Return the rotation vector accuracy
 float BNO080::getQuatRadianAccuracy()
 {
-	float quat = qToFloat(rawQuatRadianAccuracy, rotationVector_Q1);
+	float quat = qToFloat(rawQuatRadianAccuracy, rotationVectorAccuracy_Q1);
 	return (quat);
 }
 

--- a/src/SparkFun_BNO080_Arduino_Library.h
+++ b/src/SparkFun_BNO080_Arduino_Library.h
@@ -271,6 +271,7 @@ private:
 	//These Q values are defined in the datasheet but can also be obtained by querying the meta data records
 	//See the read metadata example for more info
 	int16_t rotationVector_Q1 = 14;
+	int16_t rotationVectorAccuracy_Q1 = 12; //Heading accuracy estimate in radians. The Q point is 12.
 	int16_t accelerometer_Q1 = 8;
 	int16_t linear_accelerometer_Q1 = 8;
 	int16_t gyro_Q1 = 9;


### PR DESCRIPTION
Per the SH2 manual, Section 6.5.18  Rotation Vector (0x05)
"In addition an estimate of the heading accuracy is reported. The units for the accuracy estimate are radians. The Q point is 12."

This code change gives a heading error estimate of about  π (Pi) radians for an uncalibrated BNO080.