### PR TITLE
Fix for Arduino Uno R4 minima and wifi

### DIFF
--- a/src/SparkFun_BNO080_Arduino_Library.h
+++ b/src/SparkFun_BNO080_Arduino_Library.h
@@ -45,7 +45,7 @@
 //I2C_BUFFER_LENGTH is defined in Wire.H
 #define I2C_BUFFER_LENGTH BUFFER_LENGTH
 
-#else
+#elif (!defined(ARDUINO_UNOR4_WIFI) || !defined(ARDUINO_UNOR4_MINIMA))
 
 //The catch-all default is 32
 #define I2C_BUFFER_LENGTH 32


### PR DESCRIPTION
While working with the new Uno R4 Minima I managed to get it working by changing the test I2C Buffer Length in the .h file:
```
#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__)

//I2C_BUFFER_LENGTH is defined in Wire.H
#define I2C_BUFFER_LENGTH BUFFER_LENGTH

#elif (!defined(ARDUINO_UNOR4_WIFI) || !defined(ARDUINO_UNOR4_MINIMA))

//The catch-all default is 32
#define I2C_BUFFER_LENGTH 32

#endif
```
the R4 boards has the Buffer Length specified in Wire,h as I2C_BUFFER_LENGTH already - thats why have to skip completely.

Also during testing I noticed that alot of times the chip is not found but if I did the following it would work:
```

  if (myIMU.begin() == false)
  {
    Serial.println("BNO080 not detected at default I2C address. Check your jumpers and the hookup guide. Freezing...");
    //while (1);
  }

  Wire.setClock(400000); //Increase I2C data rate to 400kHz
  myIMU.softReset();
  delay(250);

```
